### PR TITLE
#11 [FEAT] CONN-STORY-001: Player connects via WebSocket with JWT auth

### DIFF
--- a/docs/user-stories/README.md
+++ b/docs/user-stories/README.md
@@ -25,7 +25,7 @@ Total stories written: 12/12 ✅
 
 | Story ID | Title | Written | Impl Status | File |
 |----------|-------|---------|-------------|------|
-| CONN-STORY-001 | Player connects via WebSocket with JWT auth | ✅ | TODO | [conn-story-001.md](conn-story-001.md) |
+| CONN-STORY-001 | Player connects via WebSocket with JWT auth | ✅ | DONE | [conn-story-001.md](conn-story-001.md) |
 | MATCH-STORY-001 | Player joins queue and gets matched | ✅ | TODO | [match-story-001.md](match-story-001.md) |
 | GAME-STORY-001 | Player plays a card | ✅ | TODO | [game-story-001.md](game-story-001.md) |
 | GAME-STORY-002 | Player ends their turn | ✅ | TODO | [game-story-002.md](game-story-002.md) |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest>=7.0
+pyjwt>=2.8

--- a/src/connection/client.py
+++ b/src/connection/client.py
@@ -1,0 +1,29 @@
+from collections.abc import Callable
+from enum import Enum
+from typing import Any
+
+
+class ConnectionStatus(Enum):
+    DISCONNECTED = "disconnected"
+    CONNECTED = "connected"
+    AUTH_FAILED = "auth_failed"
+
+
+class WebSocketClient:
+    def __init__(
+        self,
+        base_url: str,
+        token_provider: Callable[[], str],
+        open_ws: Callable[[str], Any],
+    ) -> None:
+        self._base_url = base_url
+        self._token_provider = token_provider
+        self._open_ws = open_ws
+        self._ws: Any | None = None
+        self.status = ConnectionStatus.DISCONNECTED
+
+    def start(self) -> None:
+        token = self._token_provider()
+        url = f"{self._base_url}?token={token}"
+        self._ws = self._open_ws(url)
+        self.status = ConnectionStatus.CONNECTED

--- a/src/connection/client.py
+++ b/src/connection/client.py
@@ -21,9 +21,15 @@ class WebSocketClient:
         self._open_ws = open_ws
         self._ws: Any | None = None
         self.status = ConnectionStatus.DISCONNECTED
+        self.error_message: str | None = None
 
     def start(self) -> None:
         token = self._token_provider()
         url = f"{self._base_url}?token={token}"
-        self._ws = self._open_ws(url)
+        try:
+            self._ws = self._open_ws(url)
+        except Exception:
+            self.status = ConnectionStatus.AUTH_FAILED
+            self.error_message = "Authentication failed — please log in again"
+            return
         self.status = ConnectionStatus.CONNECTED

--- a/src/connection/handler.py
+++ b/src/connection/handler.py
@@ -15,7 +15,11 @@ def connect(
     connection_id = event["requestContext"]["connectionId"]
     token = event["queryStringParameters"]["token"]
 
-    claims = jwt.decode(token, secret, algorithms=["HS256"])
+    try:
+        claims = jwt.decode(token, secret, algorithms=["HS256"])
+    except jwt.PyJWTError:
+        return {"statusCode": 401}
+
     player_id = claims["sub"]
 
     repo.put(

--- a/src/connection/handler.py
+++ b/src/connection/handler.py
@@ -1,0 +1,28 @@
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+
+import jwt
+
+from connection.repository import ConnectionRecord, InMemoryConnectionRepository
+
+
+def connect(
+    event: dict,
+    repo: InMemoryConnectionRepository,
+    secret: str,
+    now: Callable[[], datetime] = lambda: datetime.now(UTC),
+) -> dict:
+    connection_id = event["requestContext"]["connectionId"]
+    token = event["queryStringParameters"]["token"]
+
+    claims = jwt.decode(token, secret, algorithms=["HS256"])
+    player_id = claims["sub"]
+
+    repo.put(
+        ConnectionRecord(
+            connection_id=connection_id,
+            player_id=player_id,
+            expires_at=now() + timedelta(hours=24),
+        )
+    )
+    return {"statusCode": 200}

--- a/src/connection/repository.py
+++ b/src/connection/repository.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class ConnectionRecord:
+    connection_id: str
+    player_id: str
+    expires_at: datetime
+
+
+class InMemoryConnectionRepository:
+    def __init__(self) -> None:
+        self._store: dict[str, ConnectionRecord] = {}
+
+    def put(self, record: ConnectionRecord) -> None:
+        self._store[record.connection_id] = record
+
+    def get(self, connection_id: str) -> ConnectionRecord | None:
+        return self._store.get(connection_id)

--- a/tests/test_connect_handler.py
+++ b/tests/test_connect_handler.py
@@ -1,0 +1,38 @@
+from datetime import UTC, datetime, timedelta
+
+import jwt
+
+from connection.handler import connect
+from connection.repository import InMemoryConnectionRepository
+
+
+def test_conn_be_001_1_s1_valid_jwt_stores_connection_record():
+    # GIVEN a $connect event with a valid JWT containing `sub` (playerId)
+    secret = "a-32-byte-test-secret-padding-xx"  # pragma: allowlist secret
+    now = datetime(2026, 4, 21, 12, 0, 0, tzinfo=UTC)
+    token = jwt.encode(
+        {
+            "sub": "player-42",
+            "exp": int(datetime.now(UTC).timestamp()) + 3600,
+        },
+        secret,
+        algorithm="HS256",
+    )
+    event = {
+        "requestContext": {"connectionId": "conn-abc"},
+        "queryStringParameters": {"token": token},
+    }
+    repo = InMemoryConnectionRepository()
+
+    # WHEN ConnectFunction is invoked
+    response = connect(event, repo=repo, secret=secret, now=lambda: now)
+
+    # THEN a record PK=CONN#<connectionId> with playerId and TTL +24h is written
+    stored = repo.get("conn-abc")
+    assert stored is not None
+    assert stored.player_id == "player-42"
+    assert stored.connection_id == "conn-abc"
+    assert stored.expires_at == now + timedelta(hours=24)
+
+    # AND the function returns HTTP 200
+    assert response["statusCode"] == 200

--- a/tests/test_connect_handler.py
+++ b/tests/test_connect_handler.py
@@ -36,3 +36,29 @@ def test_conn_be_001_1_s1_valid_jwt_stores_connection_record():
 
     # AND the function returns HTTP 200
     assert response["statusCode"] == 200
+
+
+def test_conn_be_001_1_s2_invalid_jwt_returns_401_without_writing():
+    # GIVEN a $connect event with an expired JWT
+    secret = "a-32-byte-test-secret-padding-xx"  # pragma: allowlist secret
+    expired_token = jwt.encode(
+        {
+            "sub": "player-42",
+            "exp": int(datetime.now(UTC).timestamp()) - 3600,
+        },
+        secret,
+        algorithm="HS256",
+    )
+    event = {
+        "requestContext": {"connectionId": "conn-xyz"},
+        "queryStringParameters": {"token": expired_token},
+    }
+    repo = InMemoryConnectionRepository()
+
+    # WHEN ConnectFunction validates the token
+    response = connect(event, repo=repo, secret=secret)
+
+    # THEN the function returns HTTP 401
+    assert response["statusCode"] == 401
+    # AND no record is written
+    assert repo.get("conn-xyz") is None

--- a/tests/test_connection_e2e.py
+++ b/tests/test_connection_e2e.py
@@ -1,0 +1,79 @@
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import jwt
+
+from connection.client import ConnectionStatus, WebSocketClient
+from connection.handler import connect
+from connection.repository import InMemoryConnectionRepository
+
+SECRET = "a-32-byte-test-secret-padding-xx"  # pragma: allowlist secret
+
+
+def _make_token(*, expired: bool = False) -> str:
+    delta = -3600 if expired else 3600
+    return jwt.encode(
+        {
+            "sub": "player-42",
+            "exp": int(datetime.now(UTC).timestamp()) + delta,
+        },
+        SECRET,
+        algorithm="HS256",
+    )
+
+
+def _server_open_ws(repo: InMemoryConnectionRepository):
+    """Simulate the WebSocket server that invokes the connect handler on $connect."""
+
+    def open_ws(url: str):
+        # parse token off the URL
+        token = url.split("?token=", 1)[1]
+        event = {
+            "requestContext": {"connectionId": str(uuid4())},
+            "queryStringParameters": {"token": token},
+        }
+        response = connect(event, repo=repo, secret=SECRET)
+        if response["statusCode"] != 200:
+            raise ConnectionRefusedError(f"server rejected: {response['statusCode']}")
+        return object()  # opaque ws handle
+
+    return open_ws
+
+
+def test_conn_story_001_s1_valid_jwt_connects_and_record_is_written():
+    # GIVEN a player with a valid JWT, and a running connection service
+    repo = InMemoryConnectionRepository()
+    client = WebSocketClient(
+        base_url="ws://localhost:8765",
+        token_provider=lambda: _make_token(),
+        open_ws=_server_open_ws(repo),
+    )
+
+    # WHEN the player connects
+    client.start()
+
+    # THEN the client is CONNECTED
+    assert client.status is ConnectionStatus.CONNECTED
+    # AND the repository holds exactly one record for player-42
+    records = [r for r in repo._store.values() if r.player_id == "player-42"]
+    assert len(records) == 1
+    # AND the record has a ~24h TTL
+    assert records[0].expires_at > datetime.now(UTC) + timedelta(hours=23)
+
+
+def test_conn_story_001_s2_invalid_jwt_is_rejected_with_no_record_written():
+    # GIVEN a player holding an expired JWT
+    repo = InMemoryConnectionRepository()
+    client = WebSocketClient(
+        base_url="ws://localhost:8765",
+        token_provider=lambda: _make_token(expired=True),
+        open_ws=_server_open_ws(repo),
+    )
+
+    # WHEN the player attempts to connect
+    client.start()
+
+    # THEN the client shows auth failure
+    assert client.status is ConnectionStatus.AUTH_FAILED
+    # AND no record is written
+    assert repo._store == {}

--- a/tests/test_infra_dependencies.py
+++ b/tests/test_infra_dependencies.py
@@ -1,0 +1,34 @@
+import shutil
+import subprocess
+
+import pytest
+
+IMAGE = "tcg-game"
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker not available in this env")
+def test_conn_infra_001_2_s1_declared_packages_importable_inside_container():
+    # GIVEN the Docker image is built with dependencies installed
+    # WHEN we run `python -c "import pytest; import domain.game"` inside the container
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            IMAGE,
+            "python",
+            "-c",
+            "import pytest; import domain.game",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    # THEN the command exits with code 0 and no ImportError is printed
+    assert result.returncode == 0, result.stderr
+    assert "ModuleNotFoundError" not in result.stderr
+    assert "ImportError" not in result.stderr

--- a/tests/test_infra_docker_build.py
+++ b/tests/test_infra_docker_build.py
@@ -1,0 +1,38 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+IMAGE = "tcg-game"
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker not available in this env")
+def test_conn_infra_001_1_s1_docker_image_builds_from_project_root():
+    # GIVEN a Dockerfile at the project root targeting Python 3.12
+    assert (PROJECT_ROOT / "Dockerfile").is_file()
+
+    # WHEN `docker build -t tcg-game .` is executed
+    build = subprocess.run(
+        ["docker", "build", "-t", IMAGE, "."],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    # THEN the build completes with exit code 0
+    assert build.returncode == 0, build.stderr
+
+    # AND `docker images tcg-game` lists the image
+    listed = subprocess.run(
+        ["docker", "images", "-q", IMAGE],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert listed.stdout.strip() != ""

--- a/tests/test_infra_pytest_discovery.py
+++ b/tests/test_infra_pytest_discovery.py
@@ -1,0 +1,28 @@
+import shutil
+import subprocess
+
+import pytest
+
+IMAGE = "tcg-game"
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker not available in this env")
+def test_conn_infra_001_3_s1_pytest_collects_tests_without_import_errors():
+    # GIVEN test files under tests/ and pyproject.toml sets pythonpath to src
+    # WHEN `docker run --rm tcg-game pytest --collect-only` is executed
+    result = subprocess.run(
+        ["docker", "run", "--rm", IMAGE, "pytest", "--collect-only", "-q"],
+        capture_output=True,
+        text=True,
+    )
+
+    # THEN pytest collects tests, exits 0, no ImportError in output
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "ImportError" not in result.stdout
+    assert "ImportError" not in result.stderr
+    # collected items are listed (at least one of the existing play-card tests)
+    assert "test_play_card" in result.stdout

--- a/tests/test_infra_pytest_in_container.py
+++ b/tests/test_infra_pytest_in_container.py
@@ -1,0 +1,35 @@
+import shutil
+import subprocess
+
+import pytest
+
+IMAGE = "tcg-game"
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+@pytest.mark.skipif(not _docker_available(), reason="docker not available in this env")
+def test_conn_infra_001_4_s1_pytest_exits_zero_inside_container():
+    # GIVEN the image is built and dependencies are installed
+    # WHEN `docker run --rm tcg-game pytest` is executed
+    # We ignore the in-container infra tests (they can't run docker from inside docker).
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            IMAGE,
+            "pytest",
+            "tests/",
+            "--ignore-glob=tests/test_infra_*.py",
+            "-v",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    # THEN all tests pass and the process exits with code 0
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "failed" not in result.stdout.lower() or " 0 failed" in result.stdout.lower()

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -1,0 +1,34 @@
+from connection.client import ConnectionStatus, WebSocketClient
+
+
+class FakeWebSocket:
+    def __init__(self, url: str):
+        self.url = url
+        self.opened = True
+
+    def close(self) -> None:
+        self.opened = False
+
+
+def test_conn_fe_001_1_s1_client_opens_connection_with_token_on_start():
+    # GIVEN the player is logged in and holds a valid JWT
+    jwt_token = "valid.jwt.token"  # pragma: allowlist secret
+    opened_urls: list[str] = []
+
+    def open_ws(url: str) -> FakeWebSocket:
+        opened_urls.append(url)
+        return FakeWebSocket(url)
+
+    client = WebSocketClient(
+        base_url="ws://localhost:8765",
+        token_provider=lambda: jwt_token,
+        open_ws=open_ws,
+    )
+
+    # WHEN the page initialises (client.start)
+    client.start()
+
+    # THEN the client opens a WebSocket with ?token=<JWT>
+    assert opened_urls == ["ws://localhost:8765?token=valid.jwt.token"]
+    # AND the connection status is "Connected"
+    assert client.status is ConnectionStatus.CONNECTED

--- a/tests/test_ws_client.py
+++ b/tests/test_ws_client.py
@@ -32,3 +32,29 @@ def test_conn_fe_001_1_s1_client_opens_connection_with_token_on_start():
     assert opened_urls == ["ws://localhost:8765?token=valid.jwt.token"]
     # AND the connection status is "Connected"
     assert client.status is ConnectionStatus.CONNECTED
+
+
+def test_conn_fe_001_1_s2_client_shows_auth_error_and_does_not_reconnect():
+    # GIVEN the stored JWT is expired (the server rejects the connection)
+    jwt_token = "expired.jwt.token"  # pragma: allowlist secret
+    open_attempts: list[str] = []
+
+    def failing_open_ws(url: str):
+        open_attempts.append(url)
+        raise ConnectionRefusedError("401 Unauthorized")
+
+    client = WebSocketClient(
+        base_url="ws://localhost:8765",
+        token_provider=lambda: jwt_token,
+        open_ws=failing_open_ws,
+    )
+
+    # WHEN the client attempts to connect
+    client.start()
+
+    # THEN the status moves to AUTH_FAILED
+    assert client.status is ConnectionStatus.AUTH_FAILED
+    # AND the UI message reflects the failure
+    assert client.error_message == "Authentication failed — please log in again"
+    # AND no automatic reconnect is attempted
+    assert len(open_attempts) == 1


### PR DESCRIPTION
## Related Issue
Closes #11

## Changes
- INFRA (4 scenarios): verify Docker build, dependency install, pytest discovery, and pytest pass inside the container
- BE (2 scenarios): `connect()` handler validates JWT via PyJWT and stores `ConnectionRecord` in `InMemoryConnectionRepository`; invalid/expired JWT → 401 and no record written
- FE (2 scenarios): `WebSocketClient` opens WS with `?token=<JWT>` and sets status CONNECTED; on rejection, status → AUTH_FAILED, shows "Authentication failed — please log in again", no auto-reconnect
- E2E: valid JWT → record written; expired JWT → rejection, no record

Each scenario was implemented RED → GREEN → REFACTOR → COMMIT per `.kiro/agents/tdd-bdd-agent.json`. Story bundle references Cognito / DynamoDB / API Gateway; per project rule these are read as "do not use AWS" — implementation uses PyJWT (HS256) and an in-memory Python repository, all runnable via `docker build && docker run`.

## Testing
- [x] All tests pass inside Docker: `docker run --rm tcg-game pytest`
- [x] Pre-commit hooks pass on every commit (black, ruff, bandit, detect-secrets, docker-test)
- [x] Commit history shows RED → GREEN per scenario