### PR TITLE
#11 [FEAT] CONN-STORY-001: Player connects via WebSocket with JWT auth

### DIFF
--- a/docs/user-stories/README.md
+++ b/docs/user-stories/README.md
@@ -25,7 +25,7 @@ Total stories written: 12/12 ✅
 
 | Story ID | Title | Written | Impl Status | File |
 |----------|-------|---------|-------------|------|
-| CONN-STORY-001 | Player connects via WebSocket with JWT auth | ✅ | TODO | [conn-story-001.md](conn-story-001.md) |
+| CONN-STORY-001 | Player connects via WebSocket with JWT auth | ✅ | DONE (BE; FE deferred) | [conn-story-001.md](conn-story-001.md) |
 | MATCH-STORY-001 | Player joins queue and gets matched | ✅ | TODO | [match-story-001.md](match-story-001.md) |
 | GAME-STORY-001 | Player plays a card | ✅ | TODO | [game-story-001.md](game-story-001.md) |
 | GAME-STORY-002 | Player ends their turn | ✅ | TODO | [game-story-002.md](game-story-002.md) |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest>=7.0
+PyJWT>=2.8

--- a/src/connection/handlers.py
+++ b/src/connection/handlers.py
@@ -7,6 +7,10 @@ from connection.repository import Connection, ConnectionRepository
 CONNECTION_TTL_SECONDS = 24 * 60 * 60
 
 
+class ConnectRejectedError(Exception):
+    pass
+
+
 @dataclass(frozen=True)
 class ConnectResult:
     accepted: bool
@@ -21,7 +25,11 @@ def connect(
     repo: ConnectionRepository,
     now_epoch: int,
 ) -> ConnectResult:
-    claims = jwt.decode(token, secret, algorithms=["HS256"])
+    try:
+        claims = jwt.decode(token, secret, algorithms=["HS256"])
+    except jwt.InvalidTokenError as exc:
+        raise ConnectRejectedError(str(exc)) from exc
+
     player_id = claims["sub"]
     repo.put(
         Connection(

--- a/src/connection/handlers.py
+++ b/src/connection/handlers.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+
+import jwt
+
+from connection.repository import Connection, ConnectionRepository
+
+CONNECTION_TTL_SECONDS = 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class ConnectResult:
+    accepted: bool
+    player_id: str | None = None
+
+
+def connect(
+    *,
+    connection_id: str,
+    token: str,
+    secret: str,
+    repo: ConnectionRepository,
+    now_epoch: int,
+) -> ConnectResult:
+    claims = jwt.decode(token, secret, algorithms=["HS256"])
+    player_id = claims["sub"]
+    repo.put(
+        Connection(
+            connection_id=connection_id,
+            player_id=player_id,
+            expires_at=now_epoch + CONNECTION_TTL_SECONDS,
+        )
+    )
+    return ConnectResult(accepted=True, player_id=player_id)

--- a/src/connection/repository.py
+++ b/src/connection/repository.py
@@ -1,0 +1,43 @@
+import sqlite3
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Connection:
+    connection_id: str
+    player_id: str
+    expires_at: int
+
+
+class ConnectionRepository:
+    def __init__(self, conn: sqlite3.Connection):
+        self._conn = conn
+
+    def init_schema(self) -> None:
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS connections (
+                connection_id TEXT PRIMARY KEY,
+                player_id TEXT NOT NULL,
+                expires_at INTEGER NOT NULL
+            )
+            """
+        )
+        self._conn.commit()
+
+    def put(self, connection: Connection) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO connections VALUES (?, ?, ?)",
+            (connection.connection_id, connection.player_id, connection.expires_at),
+        )
+        self._conn.commit()
+
+    def get(self, connection_id: str) -> Connection | None:
+        row = self._conn.execute(
+            "SELECT connection_id, player_id, expires_at FROM connections "
+            "WHERE connection_id = ?",
+            (connection_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return Connection(*row)

--- a/tests/test_conn_be_connect_handler.py
+++ b/tests/test_conn_be_connect_handler.py
@@ -1,0 +1,40 @@
+import sqlite3
+
+import jwt
+import pytest
+
+from connection.handlers import connect
+from connection.repository import ConnectionRepository
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    repo = ConnectionRepository(conn)
+    repo.init_schema()
+    return repo
+
+
+def test_conn_be_001_1_s1_valid_jwt_stores_connection_record(repo):
+    # GIVEN a connect event with a valid JWT signed with the server's secret
+    secret = "0123456789abcdef0123456789abcdef"  # pragma: allowlist secret
+    token = jwt.encode({"sub": "player-42"}, secret, algorithm="HS256")
+
+    # WHEN the connect handler runs
+    result = connect(
+        connection_id="conn-abc",
+        token=token,
+        secret=secret,
+        repo=repo,
+        now_epoch=1_700_000_000,
+    )
+
+    # THEN the handler reports success
+    assert result.accepted is True
+    assert result.player_id == "player-42"
+
+    # AND a row maps conn-abc -> player-42 with expires_at = now + 24h
+    row = repo.get("conn-abc")
+    assert row is not None
+    assert row.player_id == "player-42"
+    assert row.expires_at == 1_700_000_000 + 24 * 60 * 60

--- a/tests/test_conn_be_invalid_jwt.py
+++ b/tests/test_conn_be_invalid_jwt.py
@@ -1,0 +1,35 @@
+import sqlite3
+
+import jwt
+import pytest
+
+from connection.handlers import ConnectRejectedError, connect
+from connection.repository import ConnectionRepository
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    repo = ConnectionRepository(conn)
+    repo.init_schema()
+    return repo
+
+
+def test_conn_be_001_1_s2_invalid_jwt_rejects_without_writing(repo):
+    # GIVEN a JWT signed with a wrong secret
+    secret = "0123456789abcdef0123456789abcdef"  # pragma: allowlist secret
+    bad_secret = "ffffffffffffffffffffffffffffffff"  # pragma: allowlist secret
+    token = jwt.encode({"sub": "player-42"}, bad_secret, algorithm="HS256")
+
+    # WHEN the connect handler runs with the server's real secret
+    # THEN it raises ConnectRejectedError and does not write to the repo
+    with pytest.raises(ConnectRejectedError):
+        connect(
+            connection_id="conn-xyz",
+            token=token,
+            secret=secret,
+            repo=repo,
+            now_epoch=1_700_000_000,
+        )
+
+    assert repo.get("conn-xyz") is None

--- a/tests/test_conn_infra_dependencies.py
+++ b/tests/test_conn_infra_dependencies.py
@@ -1,0 +1,33 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(shutil.which("docker") is None, reason="docker not available")
+def test_conn_infra_001_2_s1_declared_packages_importable_inside_container():
+    # GIVEN requirements.txt lists deps and the Dockerfile runs pip install
+    project_root = Path(__file__).resolve().parent.parent
+    assert (project_root / "requirements.txt").is_file()
+    assert "pip install" in (project_root / "Dockerfile").read_text()
+
+    # WHEN the container runs a smoke import for pytest and the domain package
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "tcg-game",
+            "python",
+            "-c",
+            "import pytest; import domain.game",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    # THEN the command exits 0 with no import errors
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"
+    assert "ModuleNotFoundError" not in result.stderr
+    assert "ImportError" not in result.stderr

--- a/tests/test_conn_infra_docker_build.py
+++ b/tests/test_conn_infra_docker_build.py
@@ -1,0 +1,34 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(shutil.which("docker") is None, reason="docker not available")
+def test_conn_infra_001_1_s1_docker_image_builds_from_project_root():
+    # GIVEN a Dockerfile at the project root targeting Python 3.12
+    project_root = Path(__file__).resolve().parent.parent
+    dockerfile = project_root / "Dockerfile"
+    assert dockerfile.is_file(), "Dockerfile must exist at project root"
+    assert "python:3.12" in dockerfile.read_text(), "Dockerfile must target Python 3.12"
+
+    # WHEN docker build -t tcg-game . is executed
+    build = subprocess.run(
+        ["docker", "build", "-t", "tcg-game", "."],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+    )
+
+    # THEN the build completes with exit code 0
+    assert build.returncode == 0, f"docker build failed:\n{build.stderr}"
+
+    # AND docker images tcg-game lists the image
+    images = subprocess.run(
+        ["docker", "images", "-q", "tcg-game"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert images.stdout.strip(), "docker images tcg-game should list the image"

--- a/tests/test_conn_infra_pytest_discovery.py
+++ b/tests/test_conn_infra_pytest_discovery.py
@@ -1,0 +1,28 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(shutil.which("docker") is None, reason="docker not available")
+def test_conn_infra_001_3_s1_pytest_collects_tests_inside_container():
+    # GIVEN test files live under tests/ and pyproject sets pythonpath=src
+    project_root = Path(__file__).resolve().parent.parent
+    assert (project_root / "tests").is_dir()
+    pyproject = (project_root / "pyproject.toml").read_text()
+    assert 'pythonpath = ["src"]' in pyproject
+
+    # WHEN pytest --collect-only runs inside the container
+    result = subprocess.run(
+        ["docker", "run", "--rm", "tcg-game", "pytest", "--collect-only"],
+        capture_output=True,
+        text=True,
+    )
+
+    # THEN collection succeeds with no import errors
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"
+    assert "ImportError" not in result.stdout
+    assert "ImportError" not in result.stderr
+    # AND at least one test is collected
+    assert "<Function" in result.stdout or "test_" in result.stdout

--- a/tests/test_conn_infra_pytest_passes.py
+++ b/tests/test_conn_infra_pytest_passes.py
@@ -1,0 +1,41 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(shutil.which("docker") is None, reason="docker not available")
+@pytest.mark.skipif(
+    os.environ.get("TCG_IN_CONTAINER") == "1",
+    reason="prevents recursive docker-in-docker when run inside the image",
+)
+def test_conn_infra_001_4_s1_pytest_exits_zero_inside_container():
+    # GIVEN the image is built and deps installed (prior INFRA scenarios)
+    project_root = Path(__file__).resolve().parent.parent
+    assert (project_root / "Dockerfile").is_file()
+
+    # WHEN the full pytest suite runs inside the container (excluding the infra
+    # tests themselves, which shell out to docker and are host-only)
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-e",
+            "TCG_IN_CONTAINER=1",
+            "tcg-game",
+            "pytest",
+            "tests/",
+            "--ignore-glob=tests/test_conn_infra_*.py",
+            "-v",
+            "--tb=short",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    # THEN the process exits 0 and output shows tests ran
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert " passed" in result.stdout

--- a/tests/test_conn_story_001_e2e.py
+++ b/tests/test_conn_story_001_e2e.py
@@ -1,0 +1,58 @@
+import sqlite3
+
+import jwt
+import pytest
+
+from connection.handlers import ConnectRejectedError, connect
+from connection.repository import ConnectionRepository
+
+SECRET = "0123456789abcdef0123456789abcdef"  # pragma: allowlist secret
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    repo = ConnectionRepository(conn)
+    repo.init_schema()
+    return repo
+
+
+def test_conn_story_001_s1_successful_connect_records_mapping(repo):
+    # GIVEN a valid JWT signed with the server's secret
+    token = jwt.encode({"sub": "player-1"}, SECRET, algorithm="HS256")
+
+    # WHEN the player connects
+    result = connect(
+        connection_id="conn-1",
+        token=token,
+        secret=SECRET,
+        repo=repo,
+        now_epoch=1_700_000_000,
+    )
+
+    # THEN the connection is accepted and recorded
+    assert result.accepted is True
+    row = repo.get("conn-1")
+    assert row is not None
+    assert row.player_id == "player-1"
+
+
+def test_conn_story_001_s2_connect_rejected_with_invalid_jwt(repo):
+    # GIVEN a JWT signed with the wrong secret (stand-in for an expired/forged token)
+    token = jwt.encode(
+        {"sub": "player-2"},
+        "ffffffffffffffffffffffffffffffff",  # pragma: allowlist secret
+        algorithm="HS256",
+    )
+
+    # WHEN the player attempts to connect
+    # THEN it is rejected and nothing is recorded
+    with pytest.raises(ConnectRejectedError):
+        connect(
+            connection_id="conn-2",
+            token=token,
+            secret=SECRET,
+            repo=repo,
+            now_epoch=1_700_000_000,
+        )
+    assert repo.get("conn-2") is None


### PR DESCRIPTION
## Related Issue
Closes #11

## Changes
TDD implementation of CONN-STORY-001 scenarios, one commit per GREEN per \`tdd-bdd-agent\`:

- INFRA 001.1–001.4: verify Docker build, deps, pytest discovery, and in-container suite (host-side tests shelling out to \`docker\`; they confirm the infra on master satisfies the scenarios)
- BE 001.1-S1: \`connect()\` handler validates a PyJWT HS256 token, extracts \`sub\` as \`playerId\`, writes a row to the \`connections\` table in SQLite with \`expires_at = now + 24h\`
- BE 001.1-S2: invalid/forged JWT raises \`ConnectRejectedError\`; nothing is written to the repo
- E2E: two host-side tests exercise the Original story scenarios (S1 success, S2 rejection) through the handler boundary

New code:
- \`src/connection/__init__.py\`, \`src/connection/handlers.py\`, \`src/connection/repository.py\`
- \`PyJWT>=2.8\` in \`requirements.txt\`
- 7 new test files under \`tests/\`

FE sub-stories (\`CONN-FE-001.1-S1/S2\` — browser WebSocket lifecycle) are deferred; no browser client exists yet. Story status in the inventory is marked accordingly.

## Testing
- [x] Full pytest suite: 12 passed
- [x] \`docker build . && docker run --rm tcg-game\` runs the suite inside the container successfully
- [x] All pre-commit hooks pass (black, isort, ruff, bandit, detect-secrets, docker-test, commit-msg-format)