### PR TITLE
#17 [FEAT] MATCH-STORY-001: Player joins queue and gets matched

### DIFF
--- a/docs/user-stories/README.md
+++ b/docs/user-stories/README.md
@@ -26,7 +26,7 @@ Total stories written: 12/12 ✅
 | Story ID | Title | Written | Impl Status | File |
 |----------|-------|---------|-------------|------|
 | CONN-STORY-001 | Player connects via WebSocket with JWT auth | ✅ | DONE (BE; FE deferred) | [conn-story-001.md](conn-story-001.md) |
-| MATCH-STORY-001 | Player joins queue and gets matched | ✅ | TODO | [match-story-001.md](match-story-001.md) |
+| MATCH-STORY-001 | Player joins queue and gets matched | ✅ | DONE (BE; FE + race deferred) | [match-story-001.md](match-story-001.md) |
 | GAME-STORY-001 | Player plays a card | ✅ | TODO | [game-story-001.md](game-story-001.md) |
 | GAME-STORY-002 | Player ends their turn | ✅ | TODO | [game-story-002.md](game-story-002.md) |
 | GAME-STORY-003 | Game detects win condition | ✅ | TODO | [game-story-003.md](game-story-003.md) |

--- a/src/matchmaking/handlers.py
+++ b/src/matchmaking/handlers.py
@@ -1,3 +1,4 @@
+import uuid
 from dataclasses import dataclass
 
 from matchmaking.repository import MatchmakingRepository, QueueEntry
@@ -9,11 +10,44 @@ class JoinQueueResult:
     game: dict | None = None
 
 
+def _initial_game(game_id: str, player_a: str, player_b: str) -> dict:
+    return {
+        "game_id": game_id,
+        "player_ids": [player_a, player_b],
+        "active_player_index": 0,
+        "players": [
+            {
+                "id": player_a,
+                "hp": 30,
+                "mana": 0,
+                "mana_slots": 0,
+                "hand": [],
+                "deck": [],
+            },
+            {
+                "id": player_b,
+                "hp": 30,
+                "mana": 0,
+                "mana_slots": 0,
+                "hand": [],
+                "deck": [],
+            },
+        ],
+    }
+
+
 def join_queue(
     *,
     player_id: str,
     repo: MatchmakingRepository,
     now_epoch: int,
 ) -> JoinQueueResult:
-    repo.enqueue(QueueEntry(player_id=player_id, joined_at=now_epoch))
-    return JoinQueueResult(status="waiting")
+    opponent = repo.pop_waiting()
+    if opponent is None:
+        repo.enqueue(QueueEntry(player_id=player_id, joined_at=now_epoch))
+        return JoinQueueResult(status="waiting")
+
+    game_id = str(uuid.uuid4())
+    game = _initial_game(game_id, opponent.player_id, player_id)
+    repo.save_game(game_id, game)
+    return JoinQueueResult(status="matched", game=game)

--- a/src/matchmaking/handlers.py
+++ b/src/matchmaking/handlers.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+from matchmaking.repository import MatchmakingRepository, QueueEntry
+
+
+@dataclass(frozen=True)
+class JoinQueueResult:
+    status: str
+    game: dict | None = None
+
+
+def join_queue(
+    *,
+    player_id: str,
+    repo: MatchmakingRepository,
+    now_epoch: int,
+) -> JoinQueueResult:
+    repo.enqueue(QueueEntry(player_id=player_id, joined_at=now_epoch))
+    return JoinQueueResult(status="waiting")

--- a/src/matchmaking/repository.py
+++ b/src/matchmaking/repository.py
@@ -1,0 +1,66 @@
+import json
+import sqlite3
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class QueueEntry:
+    player_id: str
+    joined_at: int
+
+
+class MatchmakingRepository:
+    def __init__(self, conn: sqlite3.Connection):
+        self._conn = conn
+
+    def init_schema(self) -> None:
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS queue (
+                player_id TEXT PRIMARY KEY,
+                joined_at INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS games (
+                game_id TEXT PRIMARY KEY,
+                state_json TEXT NOT NULL
+            );
+            """
+        )
+        self._conn.commit()
+
+    def enqueue(self, entry: QueueEntry) -> None:
+        self._conn.execute(
+            "INSERT OR IGNORE INTO queue VALUES (?, ?)",
+            (entry.player_id, entry.joined_at),
+        )
+        self._conn.commit()
+
+    def peek_waiting(self) -> QueueEntry | None:
+        row = self._conn.execute(
+            "SELECT player_id, joined_at FROM queue ORDER BY joined_at LIMIT 1"
+        ).fetchone()
+        return QueueEntry(*row) if row else None
+
+    def pop_waiting(self) -> QueueEntry | None:
+        cur = self._conn.execute(
+            "SELECT player_id, joined_at FROM queue ORDER BY joined_at LIMIT 1"
+        )
+        row = cur.fetchone()
+        if row is None:
+            return None
+        self._conn.execute("DELETE FROM queue WHERE player_id = ?", (row[0],))
+        self._conn.commit()
+        return QueueEntry(*row)
+
+    def save_game(self, game_id: str, state: dict) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO games VALUES (?, ?)",
+            (game_id, json.dumps(state)),
+        )
+        self._conn.commit()
+
+    def get_game(self, game_id: str) -> dict | None:
+        row = self._conn.execute(
+            "SELECT state_json FROM games WHERE game_id = ?", (game_id,)
+        ).fetchone()
+        return json.loads(row[0]) if row else None

--- a/tests/test_match_be_match.py
+++ b/tests/test_match_be_match.py
@@ -1,0 +1,41 @@
+import sqlite3
+
+import pytest
+
+from matchmaking.handlers import join_queue
+from matchmaking.repository import MatchmakingRepository
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    return r
+
+
+def test_match_be_001_1_s1_second_player_triggers_match(repo):
+    # GIVEN player A is waiting in the queue
+    join_queue(player_id="player-A", repo=repo, now_epoch=1_700_000_000)
+    assert repo.peek_waiting().player_id == "player-A"
+
+    # WHEN player B joins
+    result = join_queue(player_id="player-B", repo=repo, now_epoch=1_700_000_001)
+
+    # THEN both players are matched and a game is created
+    assert result.status == "matched"
+    assert result.game is not None
+    assert set(result.game["player_ids"]) == {"player-A", "player-B"}
+    # initial state: 30 HP, 0 mana, active player is one of them
+    for p in result.game["players"]:
+        assert p["hp"] == 30
+        assert p["mana"] == 0
+        assert p["mana_slots"] == 0
+
+    # AND the queue is empty
+    assert repo.peek_waiting() is None
+
+    # AND the game row is persisted
+    stored = repo.get_game(result.game["game_id"])
+    assert stored is not None
+    assert set(stored["player_ids"]) == {"player-A", "player-B"}

--- a/tests/test_match_be_waiting.py
+++ b/tests/test_match_be_waiting.py
@@ -1,0 +1,30 @@
+import sqlite3
+
+import pytest
+
+from matchmaking.handlers import join_queue
+from matchmaking.repository import MatchmakingRepository
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    return r
+
+
+def test_match_be_001_1_s2_queue_row_written_and_waiting_response(repo):
+    # GIVEN the queue table is empty
+    assert repo.peek_waiting() is None
+
+    # WHEN the join_queue handler runs for player-1
+    result = join_queue(player_id="player-1", repo=repo, now_epoch=1_700_000_000)
+
+    # THEN the player is queued and receives a waiting status
+    assert result.status == "waiting"
+    assert result.game is None
+    row = repo.peek_waiting()
+    assert row is not None
+    assert row.player_id == "player-1"
+    assert row.joined_at == 1_700_000_000

--- a/tests/test_match_story_001_e2e.py
+++ b/tests/test_match_story_001_e2e.py
@@ -1,0 +1,39 @@
+import sqlite3
+
+import pytest
+
+from matchmaking.handlers import join_queue
+from matchmaking.repository import MatchmakingRepository
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    return r
+
+
+def test_match_story_001_s1_two_players_match_successfully(repo):
+    # GIVEN player A is waiting
+    a = join_queue(player_id="player-A", repo=repo, now_epoch=1_700_000_000)
+    assert a.status == "waiting"
+
+    # WHEN player B joins
+    b = join_queue(player_id="player-B", repo=repo, now_epoch=1_700_000_001)
+
+    # THEN both are matched, queue is empty, a game exists
+    assert b.status == "matched"
+    assert repo.peek_waiting() is None
+    assert repo.get_game(b.game["game_id"]) is not None
+
+
+def test_match_story_001_s2_first_player_to_join_receives_waiting(repo):
+    # GIVEN the queue is empty
+    # WHEN a connected player joins
+    result = join_queue(player_id="player-1", repo=repo, now_epoch=1_700_000_000)
+
+    # THEN the player is queued and receives waiting status
+    assert result.status == "waiting"
+    assert result.game is None
+    assert repo.peek_waiting().player_id == "player-1"


### PR DESCRIPTION
## Related Issue
Closes #17

## Changes
- New bounded context \`src/matchmaking/\` with a SQLite-backed \`MatchmakingRepository\` (tables: \`queue\`, \`games\`) and a pure \`join_queue()\` handler.
- MATCH-BE-001.1-S2 (waiting): first joiner is enqueued and receives \`{"status": "waiting"}\`.
- MATCH-BE-001.1-S1 (match): second joiner pops the waiting opponent, creates an initial GameState (both players at 30 HP, 0 mana, 0 slots, empty hand/deck), persists it in \`games\`, and returns \`{"status": "matched", "game": {...}}\`.
- E2E tests at the handler boundary cover the two Original-story scenarios.

## Deferred (kept simple)
- MATCH-BE-001.1-S3 (concurrent join race): needs real threading + row-level locking; skipped for kata scope.
- FE sub-stories: no browser client yet.
- INFRA sub-stories: already satisfied on master by the shared Dockerfile + pytest setup.

## Testing
- [x] Full pytest suite: 15 passed
- [x] \`docker build\` + \`docker run --rm tcg-game\` pass
- [x] All pre-commit hooks pass