### PR TITLE
#14 [FEAT] GAME-STORY-001: Player plays a card

### DIFF
--- a/docs/user-stories/README.md
+++ b/docs/user-stories/README.md
@@ -27,7 +27,7 @@ Total stories written: 12/12 ✅
 |----------|-------|---------|-------------|------|
 | CONN-STORY-001 | Player connects via WebSocket with JWT auth | ✅ | DONE (BE; FE deferred) | [conn-story-001.md](conn-story-001.md) |
 | MATCH-STORY-001 | Player joins queue and gets matched | ✅ | DONE (BE; FE + race deferred) | [match-story-001.md](match-story-001.md) |
-| GAME-STORY-001 | Player plays a card | ✅ | TODO | [game-story-001.md](game-story-001.md) |
+| GAME-STORY-001 | Player plays a card | ✅ | DONE (BE; FE deferred) | [game-story-001.md](game-story-001.md) |
 | GAME-STORY-002 | Player ends their turn | ✅ | TODO | [game-story-002.md](game-story-002.md) |
 | GAME-STORY-003 | Game detects win condition | ✅ | TODO | [game-story-003.md](game-story-003.md) |
 

--- a/src/domain/game.py
+++ b/src/domain/game.py
@@ -3,10 +3,17 @@ from dataclasses import replace
 from domain.models import GameState, RuleViolationError
 
 
-def play_card(state: GameState, card_index: int) -> GameState:
+def play_card(
+    state: GameState,
+    card_index: int,
+    acting_player_id: str | None = None,
+) -> GameState:
     i = state.active_player_index
     active = state.players[i]
     opponent = state.players[1 - i]
+
+    if acting_player_id is not None and acting_player_id != active.id:
+        raise RuleViolationError("not your turn")
 
     if card_index < 0 or card_index >= len(active.hand):
         raise RuleViolationError("invalid card index")

--- a/src/game/handlers.py
+++ b/src/game/handlers.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+
+from domain.game import play_card
+from domain.models import GameState, Player, RuleViolationError
+from matchmaking.repository import MatchmakingRepository
+
+
+@dataclass(frozen=True)
+class PlayCardResult:
+    game: dict | None = None
+    error: str | None = None
+
+
+def _dict_to_state(d: dict) -> GameState:
+    players = [
+        Player(
+            id=p["id"],
+            hp=p["hp"],
+            mana=p["mana"],
+            mana_slots=p["mana_slots"],
+            hand=list(p["hand"]),
+            deck=list(p["deck"]),
+        )
+        for p in d["players"]
+    ]
+    return GameState(players=players, active_player_index=d["active_player_index"])
+
+
+def _state_to_dict(game_id: str, state: GameState, player_ids: list[str]) -> dict:
+    return {
+        "game_id": game_id,
+        "player_ids": player_ids,
+        "active_player_index": state.active_player_index,
+        "players": [
+            {
+                "id": p.id,
+                "hp": p.hp,
+                "mana": p.mana,
+                "mana_slots": p.mana_slots,
+                "hand": list(p.hand),
+                "deck": list(p.deck),
+            }
+            for p in state.players
+        ],
+    }
+
+
+def play_card_handler(
+    *,
+    game_id: str,
+    acting_player_id: str,
+    card_index: int,
+    repo: MatchmakingRepository,
+) -> PlayCardResult:
+    stored = repo.get_game(game_id)
+    if stored is None:
+        return PlayCardResult(error="game not found")
+
+    state = _dict_to_state(stored)
+    try:
+        new_state = play_card(
+            state, card_index=card_index, acting_player_id=acting_player_id
+        )
+    except RuleViolationError as exc:
+        return PlayCardResult(error=str(exc))
+
+    new_dict = _state_to_dict(game_id, new_state, stored["player_ids"])
+    repo.save_game(game_id, new_dict)
+    return PlayCardResult(game=new_dict)

--- a/tests/test_game_be_play_card_handler.py
+++ b/tests/test_game_be_play_card_handler.py
@@ -1,0 +1,107 @@
+import sqlite3
+
+import pytest
+
+from game.handlers import PlayCardResult, play_card_handler
+from matchmaking.repository import MatchmakingRepository
+
+
+def _initial_game(game_id: str) -> dict:
+    return {
+        "game_id": game_id,
+        "player_ids": ["p1", "p2"],
+        "active_player_index": 0,
+        "players": [
+            {
+                "id": "p1",
+                "hp": 30,
+                "mana": 4,
+                "mana_slots": 4,
+                "hand": [1, 3, 2],
+                "deck": [],
+            },
+            {"id": "p2", "hp": 30, "mana": 0, "mana_slots": 0, "hand": [], "deck": []},
+        ],
+    }
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    r.save_game("g1", _initial_game("g1"))
+    return r
+
+
+def test_game_be_001_1_s1_valid_play_persists_and_returns_updated_state(repo):
+    # GIVEN saved game: p1 active, mana=4, can play card index 1 (cost=3)
+    # WHEN the handler runs for p1
+    result = play_card_handler(
+        game_id="g1", acting_player_id="p1", card_index=1, repo=repo
+    )
+
+    # THEN it returns the updated state and the repo now holds the new state
+    assert isinstance(result, PlayCardResult)
+    assert result.error is None
+    assert result.game is not None
+    # active player's mana reduced 4->1; card removed; opponent HP 30->27
+    assert result.game["players"][0]["mana"] == 1
+    assert result.game["players"][0]["hand"] == [1, 2]
+    assert result.game["players"][1]["hp"] == 27
+    stored = repo.get_game("g1")
+    assert stored["players"][1]["hp"] == 27
+
+
+def test_game_be_001_1_s2_insufficient_mana_returns_error_and_does_not_persist(repo):
+    # GIVEN a saved game where p1 will try to play a card that costs too much
+    # override state so mana=2 and card index 0 costs 5 forcing the error
+    repo.save_game(
+        "g1",
+        {
+            **_initial_game("g1"),
+            "players": [
+                {
+                    "id": "p1",
+                    "hp": 30,
+                    "mana": 2,
+                    "mana_slots": 2,
+                    "hand": [5, 3],
+                    "deck": [],
+                },
+                {
+                    "id": "p2",
+                    "hp": 30,
+                    "mana": 0,
+                    "mana_slots": 0,
+                    "hand": [],
+                    "deck": [],
+                },
+            ],
+        },
+    )
+
+    # WHEN p1 tries to play card 0 (cost=5, mana=2)
+    result = play_card_handler(
+        game_id="g1", acting_player_id="p1", card_index=0, repo=repo
+    )
+
+    # THEN an error is returned and state is unchanged
+    assert result.error == "not enough mana"
+    assert result.game is None
+    stored = repo.get_game("g1")
+    assert stored["players"][0]["mana"] == 2  # unchanged
+    assert stored["players"][0]["hand"] == [5, 3]
+
+
+def test_game_be_001_1_s3_not_active_player_returns_error(repo):
+    # WHEN the inactive player (p2) tries to play
+    result = play_card_handler(
+        game_id="g1", acting_player_id="p2", card_index=0, repo=repo
+    )
+
+    # THEN error is "not your turn" and state is unchanged
+    assert result.error == "not your turn"
+    assert result.game is None
+    stored = repo.get_game("g1")
+    assert stored["players"][0]["mana"] == 4

--- a/tests/test_game_story_001_e2e.py
+++ b/tests/test_game_story_001_e2e.py
@@ -1,0 +1,73 @@
+import sqlite3
+
+import pytest
+
+from game.handlers import play_card_handler
+from matchmaking.handlers import join_queue
+from matchmaking.repository import MatchmakingRepository
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    return r
+
+
+def _deal_hand(repo, game_id: str, hand: list[int], mana: int) -> None:
+    game = repo.get_game(game_id)
+    game["players"][0] = {
+        **game["players"][0],
+        "hand": hand,
+        "mana": mana,
+        "mana_slots": mana,
+    }
+    repo.save_game(game_id, game)
+
+
+def test_game_story_001_s1_valid_play_updates_game(repo):
+    # GIVEN a game created by matchmaking for A and B
+    join_queue(player_id="A", repo=repo, now_epoch=1)
+    match = join_queue(player_id="B", repo=repo, now_epoch=2)
+    gid = match.game["game_id"]
+    active_id = match.game["players"][0]["id"]
+    _deal_hand(repo, gid, hand=[1, 3, 2], mana=4)
+
+    # WHEN the active player plays index 1 (cost=3)
+    result = play_card_handler(
+        game_id=gid, acting_player_id=active_id, card_index=1, repo=repo
+    )
+
+    # THEN the state reflects the play and is persisted
+    assert result.error is None
+    assert result.game["players"][0]["mana"] == 1
+    assert result.game["players"][0]["hand"] == [1, 2]
+    assert result.game["players"][1]["hp"] == 27
+
+
+def test_game_story_001_s2_insufficient_mana_rejected(repo):
+    join_queue(player_id="A", repo=repo, now_epoch=1)
+    match = join_queue(player_id="B", repo=repo, now_epoch=2)
+    gid = match.game["game_id"]
+    active_id = match.game["players"][0]["id"]
+    _deal_hand(repo, gid, hand=[5, 3], mana=2)
+
+    result = play_card_handler(
+        game_id=gid, acting_player_id=active_id, card_index=0, repo=repo
+    )
+    assert result.error == "not enough mana"
+    # state unchanged
+    assert repo.get_game(gid)["players"][0]["mana"] == 2
+
+
+def test_game_story_001_s3_wrong_player_rejected(repo):
+    join_queue(player_id="A", repo=repo, now_epoch=1)
+    match = join_queue(player_id="B", repo=repo, now_epoch=2)
+    gid = match.game["game_id"]
+    inactive_id = match.game["players"][1]["id"]
+
+    result = play_card_handler(
+        game_id=gid, acting_player_id=inactive_id, card_index=0, repo=repo
+    )
+    assert result.error == "not your turn"

--- a/tests/test_play_card_not_your_turn.py
+++ b/tests/test_play_card_not_your_turn.py
@@ -1,0 +1,20 @@
+import pytest
+
+from domain.game import play_card
+from domain.models import GameState, Player, RuleViolationError
+
+
+def test_game_story_001_s3_inactive_player_cannot_play():
+    # GIVEN it is player 0's turn but player 1 tries to play
+    active = Player(id="p1", hp=30, mana=10, mana_slots=10, hand=[1, 2], deck=[])
+    inactive = Player(id="p2", hp=30, mana=10, mana_slots=10, hand=[3, 4], deck=[])
+    state = GameState(players=[active, inactive], active_player_index=0)
+
+    # WHEN play_card is called with acting_player_id of the inactive player
+    # THEN a RuleViolationError "not your turn" is raised
+    with pytest.raises(RuleViolationError, match="not your turn"):
+        play_card(state, card_index=0, acting_player_id="p2")
+
+    # AND state is unchanged
+    assert state.players[0].hand == [1, 2]
+    assert state.players[1].hand == [3, 4]


### PR DESCRIPTION
## Related Issue
Closes #14

## Changes
- Extended pure \`play_card()\` in \`src/domain/game.py\` to reject plays from the inactive player (\`acting_player_id\` kwarg).
- New \`src/game/handlers.py\` with \`play_card_handler()\` that loads the game via \`MatchmakingRepository\`, delegates to the pure domain function, persists the new state, and returns \`PlayCardResult(game=..., error=...)\`. Rule violations surface as typed error strings without touching stored state.
- Handler-level tests (BE) for valid play, insufficient mana, and not-your-turn.
- E2E tests wiring matchmaking → game handler to confirm the story scenarios end-to-end.

## Testing
- [x] Full pytest suite: 22 passed
- [x] \`docker build\` + \`docker run --rm tcg-game\` pass
- [x] All pre-commit hooks pass