### PR TITLE
#15 [FEAT] GAME-STORY-002: Player ends their turn

### DIFF
--- a/docs/user-stories/README.md
+++ b/docs/user-stories/README.md
@@ -28,7 +28,7 @@ Total stories written: 12/12 ✅
 | CONN-STORY-001 | Player connects via WebSocket with JWT auth | ✅ | DONE (BE; FE deferred) | [conn-story-001.md](conn-story-001.md) |
 | MATCH-STORY-001 | Player joins queue and gets matched | ✅ | DONE (BE; FE + race deferred) | [match-story-001.md](match-story-001.md) |
 | GAME-STORY-001 | Player plays a card | ✅ | DONE (BE; FE deferred) | [game-story-001.md](game-story-001.md) |
-| GAME-STORY-002 | Player ends their turn | ✅ | TODO | [game-story-002.md](game-story-002.md) |
+| GAME-STORY-002 | Player ends their turn | ✅ | DONE (BE; FE deferred) | [game-story-002.md](game-story-002.md) |
 | GAME-STORY-003 | Game detects win condition | ✅ | TODO | [game-story-003.md](game-story-003.md) |
 
 ### SUPPORTING Stories (80% → remaining 20% value)

--- a/src/domain/game.py
+++ b/src/domain/game.py
@@ -2,6 +2,9 @@ from dataclasses import replace
 
 from domain.models import GameState, RuleViolationError
 
+MAX_MANA_SLOTS = 10
+MAX_HAND_SIZE = 5
+
 
 def play_card(
     state: GameState,
@@ -29,3 +32,34 @@ def play_card(
 
     new_players = [new_active, new_opponent] if i == 0 else [new_opponent, new_active]
     return replace(state, players=new_players)
+
+
+def end_turn(state: GameState) -> GameState:
+    i = state.active_player_index
+    opp = state.players[1 - i]
+
+    new_slots = min(opp.mana_slots + 1, MAX_MANA_SLOTS)
+    new_mana = new_slots
+    new_hand = list(opp.hand)
+    new_deck = list(opp.deck)
+    new_hp = opp.hp
+
+    if not new_deck:
+        new_hp -= 1
+    else:
+        drawn = new_deck.pop(0)
+        if len(new_hand) < MAX_HAND_SIZE:
+            new_hand.append(drawn)
+        # else Overload: drawn card is discarded
+
+    new_opp = replace(
+        opp,
+        mana_slots=new_slots,
+        mana=new_mana,
+        hand=new_hand,
+        deck=new_deck,
+        hp=new_hp,
+    )
+    new_players = list(state.players)
+    new_players[1 - i] = new_opp
+    return replace(state, players=new_players, active_player_index=1 - i)

--- a/src/game/handlers.py
+++ b/src/game/handlers.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from domain.game import play_card
+from domain.game import end_turn, play_card
 from domain.models import GameState, Player, RuleViolationError
 from matchmaking.repository import MatchmakingRepository
 
@@ -67,3 +67,30 @@ def play_card_handler(
     new_dict = _state_to_dict(game_id, new_state, stored["player_ids"])
     repo.save_game(game_id, new_dict)
     return PlayCardResult(game=new_dict)
+
+
+@dataclass(frozen=True)
+class EndTurnResult:
+    game: dict | None = None
+    error: str | None = None
+
+
+def end_turn_handler(
+    *,
+    game_id: str,
+    acting_player_id: str,
+    repo: MatchmakingRepository,
+) -> EndTurnResult:
+    stored = repo.get_game(game_id)
+    if stored is None:
+        return EndTurnResult(error="game not found")
+
+    state = _dict_to_state(stored)
+    active = state.players[state.active_player_index]
+    if acting_player_id != active.id:
+        return EndTurnResult(error="not your turn")
+
+    new_state = end_turn(state)
+    new_dict = _state_to_dict(game_id, new_state, stored["player_ids"])
+    repo.save_game(game_id, new_dict)
+    return EndTurnResult(game=new_dict)

--- a/tests/test_end_turn_domain.py
+++ b/tests/test_end_turn_domain.py
@@ -1,0 +1,63 @@
+from domain.game import end_turn
+from domain.models import GameState, Player
+
+
+def _state(
+    active_hand=None,
+    opp_deck=None,
+    opp_hand=None,
+    opp_mana_slots=3,
+    opp_hp=30,
+):
+    active = Player(
+        id="p1", hp=30, mana=0, mana_slots=0, hand=list(active_hand or []), deck=[]
+    )
+    opp = Player(
+        id="p2",
+        hp=opp_hp,
+        mana=0,
+        mana_slots=opp_mana_slots,
+        hand=list(opp_hand or []),
+        deck=list(opp_deck or []),
+    )
+    return GameState(players=[active, opp], active_player_index=0)
+
+
+def test_game_story_002_s1_normal_end_turn_opponent_draws_and_becomes_active():
+    state = _state(opp_deck=[7, 8], opp_hand=[1], opp_mana_slots=3)
+    new_state = end_turn(state)
+    opp = new_state.players[1]
+    assert opp.mana_slots == 4
+    assert opp.mana == 4
+    assert opp.hand == [1, 7]  # top of deck drawn
+    assert opp.deck == [8]
+    assert new_state.active_player_index == 1
+
+
+def test_game_story_002_s2_bleeding_out_on_empty_deck():
+    state = _state(opp_deck=[], opp_hand=[1], opp_mana_slots=3, opp_hp=30)
+    new_state = end_turn(state)
+    opp = new_state.players[1]
+    assert opp.hp == 29
+    assert opp.hand == [1]
+    assert opp.mana_slots == 4
+    assert opp.mana == 4
+    assert new_state.active_player_index == 1
+
+
+def test_game_story_002_s3_overload_discards_when_hand_full():
+    state = _state(opp_deck=[9, 8], opp_hand=[1, 2, 3, 4, 5], opp_mana_slots=3)
+    new_state = end_turn(state)
+    opp = new_state.players[1]
+    assert len(opp.hand) == 5
+    assert opp.hand == [1, 2, 3, 4, 5]  # no new card added
+    assert opp.deck == [8]  # top card discarded
+    assert new_state.active_player_index == 1
+
+
+def test_game_story_002_s4_mana_slots_capped_at_10():
+    state = _state(opp_deck=[1], opp_hand=[], opp_mana_slots=10)
+    new_state = end_turn(state)
+    opp = new_state.players[1]
+    assert opp.mana_slots == 10
+    assert opp.mana == 10

--- a/tests/test_game_be_end_turn_handler.py
+++ b/tests/test_game_be_end_turn_handler.py
@@ -1,0 +1,57 @@
+import sqlite3
+
+import pytest
+
+from game.handlers import end_turn_handler
+from matchmaking.repository import MatchmakingRepository
+
+
+def _saved_game() -> dict:
+    return {
+        "game_id": "g1",
+        "player_ids": ["p1", "p2"],
+        "active_player_index": 0,
+        "players": [
+            {
+                "id": "p1",
+                "hp": 30,
+                "mana": 3,
+                "mana_slots": 3,
+                "hand": [1],
+                "deck": [],
+            },
+            {
+                "id": "p2",
+                "hp": 30,
+                "mana": 0,
+                "mana_slots": 3,
+                "hand": [],
+                "deck": [4, 5],
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    r.save_game("g1", _saved_game())
+    return r
+
+
+def test_game_be_002_1_s1_end_turn_applied_and_persisted(repo):
+    result = end_turn_handler(game_id="g1", acting_player_id="p1", repo=repo)
+    assert result.error is None
+    assert result.game["active_player_index"] == 1
+    assert result.game["players"][1]["mana_slots"] == 4
+    assert result.game["players"][1]["hand"] == [4]
+    stored = repo.get_game("g1")
+    assert stored["active_player_index"] == 1
+
+
+def test_game_be_002_1_s2_wrong_player_rejected(repo):
+    result = end_turn_handler(game_id="g1", acting_player_id="p2", repo=repo)
+    assert result.error == "not your turn"
+    assert repo.get_game("g1")["active_player_index"] == 0

--- a/tests/test_game_story_002_e2e.py
+++ b/tests/test_game_story_002_e2e.py
@@ -1,0 +1,69 @@
+import sqlite3
+
+import pytest
+
+from game.handlers import end_turn_handler
+from matchmaking.handlers import join_queue
+from matchmaking.repository import MatchmakingRepository
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    return r
+
+
+def _arm_game(repo, opp_deck, opp_hand, opp_slots=3):
+    join_queue(player_id="A", repo=repo, now_epoch=1)
+    match = join_queue(player_id="B", repo=repo, now_epoch=2)
+    game = match.game
+    game["players"][1] = {
+        **game["players"][1],
+        "deck": opp_deck,
+        "hand": opp_hand,
+        "mana_slots": opp_slots,
+    }
+    repo.save_game(game["game_id"], game)
+    return game
+
+
+def test_game_story_002_s1_normal_end_turn(repo):
+    game = _arm_game(repo, opp_deck=[7], opp_hand=[])
+    active_id = game["players"][0]["id"]
+    result = end_turn_handler(
+        game_id=game["game_id"], acting_player_id=active_id, repo=repo
+    )
+    assert result.error is None
+    assert result.game["active_player_index"] == 1
+    assert result.game["players"][1]["mana_slots"] == 4
+    assert result.game["players"][1]["hand"] == [7]
+
+
+def test_game_story_002_s2_bleeding_out(repo):
+    game = _arm_game(repo, opp_deck=[], opp_hand=[])
+    active_id = game["players"][0]["id"]
+    result = end_turn_handler(
+        game_id=game["game_id"], acting_player_id=active_id, repo=repo
+    )
+    assert result.game["players"][1]["hp"] == 29
+
+
+def test_game_story_002_s3_overload_discards(repo):
+    game = _arm_game(repo, opp_deck=[9, 8], opp_hand=[1, 2, 3, 4, 5])
+    active_id = game["players"][0]["id"]
+    result = end_turn_handler(
+        game_id=game["game_id"], acting_player_id=active_id, repo=repo
+    )
+    assert len(result.game["players"][1]["hand"]) == 5
+    assert result.game["players"][1]["deck"] == [8]
+
+
+def test_game_story_002_s4_wrong_player_rejected(repo):
+    game = _arm_game(repo, opp_deck=[7], opp_hand=[])
+    inactive_id = game["players"][1]["id"]
+    result = end_turn_handler(
+        game_id=game["game_id"], acting_player_id=inactive_id, repo=repo
+    )
+    assert result.error == "not your turn"


### PR DESCRIPTION
## Related Issue
Closes #15

## Changes
- Pure \`end_turn()\` in \`src/domain/game.py\` covering the four rule branches: normal draw + mana increment, Bleeding Out on empty deck, Overload on full hand, and mana-slot cap at 10.
- \`end_turn_handler()\` in \`src/game/handlers.py\` that loads the game via \`MatchmakingRepository\`, rejects when the caller is not the active player, delegates to the pure domain function, and persists the new state.
- Domain tests for all four scenarios plus handler-level tests and story-level E2E tests wiring matchmaking + end-turn.

## Testing
- [x] Full pytest suite: 32 passed
- [x] \`docker build\` + \`docker run --rm tcg-game\` pass
- [x] All pre-commit hooks pass