### PR TITLE
#16 [FEAT] GAME-STORY-003: Game detects win condition

### DIFF
--- a/docs/user-stories/README.md
+++ b/docs/user-stories/README.md
@@ -3,7 +3,7 @@
 ## Pareto Progress
 
 ```
-Pareto Progress: 5/5 core stories (100% of 20% core stories)
+Pareto Progress: 5/5 core stories written, 5/5 core stories implemented (BE)
 Core functionality coverage: ~80% of 80% target ✅
 Supporting stories written: 7/7 (100%)
 Total stories written: 12/12 ✅
@@ -29,7 +29,7 @@ Total stories written: 12/12 ✅
 | MATCH-STORY-001 | Player joins queue and gets matched | ✅ | DONE (BE; FE + race deferred) | [match-story-001.md](match-story-001.md) |
 | GAME-STORY-001 | Player plays a card | ✅ | DONE (BE; FE deferred) | [game-story-001.md](game-story-001.md) |
 | GAME-STORY-002 | Player ends their turn | ✅ | DONE (BE; FE deferred) | [game-story-002.md](game-story-002.md) |
-| GAME-STORY-003 | Game detects win condition | ✅ | TODO | [game-story-003.md](game-story-003.md) |
+| GAME-STORY-003 | Game detects win condition | ✅ | DONE (BE; FE deferred) | [game-story-003.md](game-story-003.md) |
 
 ### SUPPORTING Stories (80% → remaining 20% value)
 

--- a/src/domain/game.py
+++ b/src/domain/game.py
@@ -63,3 +63,11 @@ def end_turn(state: GameState) -> GameState:
     new_players = list(state.players)
     new_players[1 - i] = new_opp
     return replace(state, players=new_players, active_player_index=1 - i)
+
+
+def is_game_over(state: GameState) -> str | None:
+    for p in state.players:
+        if p.hp <= 0:
+            winner = next(o for o in state.players if o.id != p.id)
+            return winner.id
+    return None

--- a/src/game/handlers.py
+++ b/src/game/handlers.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from domain.game import end_turn, play_card
+from domain.game import end_turn, is_game_over, play_card
 from domain.models import GameState, Player, RuleViolationError
 from matchmaking.repository import MatchmakingRepository
 
@@ -9,6 +9,14 @@ from matchmaking.repository import MatchmakingRepository
 class PlayCardResult:
     game: dict | None = None
     error: str | None = None
+    winner: str | None = None
+
+
+@dataclass(frozen=True)
+class EndTurnResult:
+    game: dict | None = None
+    error: str | None = None
+    winner: str | None = None
 
 
 def _dict_to_state(d: dict) -> GameState:
@@ -55,6 +63,8 @@ def play_card_handler(
     stored = repo.get_game(game_id)
     if stored is None:
         return PlayCardResult(error="game not found")
+    if stored.get("winner"):
+        return PlayCardResult(error="game over")
 
     state = _dict_to_state(stored)
     try:
@@ -65,14 +75,11 @@ def play_card_handler(
         return PlayCardResult(error=str(exc))
 
     new_dict = _state_to_dict(game_id, new_state, stored["player_ids"])
+    winner = is_game_over(new_state)
+    if winner is not None:
+        new_dict["winner"] = winner
     repo.save_game(game_id, new_dict)
-    return PlayCardResult(game=new_dict)
-
-
-@dataclass(frozen=True)
-class EndTurnResult:
-    game: dict | None = None
-    error: str | None = None
+    return PlayCardResult(game=new_dict, winner=winner)
 
 
 def end_turn_handler(
@@ -84,6 +91,8 @@ def end_turn_handler(
     stored = repo.get_game(game_id)
     if stored is None:
         return EndTurnResult(error="game not found")
+    if stored.get("winner"):
+        return EndTurnResult(error="game over")
 
     state = _dict_to_state(stored)
     active = state.players[state.active_player_index]
@@ -92,5 +101,8 @@ def end_turn_handler(
 
     new_state = end_turn(state)
     new_dict = _state_to_dict(game_id, new_state, stored["player_ids"])
+    winner = is_game_over(new_state)
+    if winner is not None:
+        new_dict["winner"] = winner
     repo.save_game(game_id, new_dict)
-    return EndTurnResult(game=new_dict)
+    return EndTurnResult(game=new_dict, winner=winner)

--- a/tests/test_game_story_003_e2e.py
+++ b/tests/test_game_story_003_e2e.py
@@ -1,0 +1,52 @@
+import sqlite3
+
+import pytest
+
+from game.handlers import end_turn_handler, play_card_handler
+from matchmaking.handlers import join_queue
+from matchmaking.repository import MatchmakingRepository
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    return r
+
+
+def _arm(repo, active_hand, active_mana, opp_hp, opp_deck):
+    join_queue(player_id="A", repo=repo, now_epoch=1)
+    match = join_queue(player_id="B", repo=repo, now_epoch=2)
+    game = match.game
+    game["players"][0] = {
+        **game["players"][0],
+        "hand": active_hand,
+        "mana": active_mana,
+        "mana_slots": active_mana,
+    }
+    game["players"][1] = {**game["players"][1], "hp": opp_hp, "deck": opp_deck}
+    repo.save_game(game["game_id"], game)
+    return game
+
+
+def test_game_story_003_s1_win_by_card_damage(repo):
+    # opponent has 2 HP; active player plays a card of cost 3
+    game = _arm(repo, active_hand=[3], active_mana=3, opp_hp=2, opp_deck=[])
+    active_id = game["players"][0]["id"]
+    result = play_card_handler(
+        game_id=game["game_id"], acting_player_id=active_id, card_index=0, repo=repo
+    )
+    assert result.winner == active_id
+    assert result.game["players"][1]["hp"] <= 0
+
+
+def test_game_story_003_s2_win_by_bleeding_out(repo):
+    # opponent has 1 HP and empty deck
+    game = _arm(repo, active_hand=[], active_mana=0, opp_hp=1, opp_deck=[])
+    active_id = game["players"][0]["id"]
+    result = end_turn_handler(
+        game_id=game["game_id"], acting_player_id=active_id, repo=repo
+    )
+    assert result.winner == active_id
+    assert result.game["players"][1]["hp"] == 0

--- a/tests/test_handlers_game_over.py
+++ b/tests/test_handlers_game_over.py
@@ -1,0 +1,70 @@
+import sqlite3
+
+import pytest
+
+from game.handlers import end_turn_handler, play_card_handler
+from matchmaking.repository import MatchmakingRepository
+
+
+def _game(hp_opp=30, mana=10, hand=None, opp_deck=None):
+    return {
+        "game_id": "g1",
+        "player_ids": ["p1", "p2"],
+        "active_player_index": 0,
+        "players": [
+            {
+                "id": "p1",
+                "hp": 30,
+                "mana": mana,
+                "mana_slots": mana,
+                "hand": list(hand or [5]),
+                "deck": [],
+            },
+            {
+                "id": "p2",
+                "hp": hp_opp,
+                "mana": 0,
+                "mana_slots": 0,
+                "hand": [],
+                "deck": list(opp_deck or []),
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    return r
+
+
+def test_game_be_003_2_s1_play_card_emits_winner_on_lethal_damage(repo):
+    repo.save_game("g1", _game(hp_opp=2, mana=3, hand=[3]))
+    result = play_card_handler(
+        game_id="g1", acting_player_id="p1", card_index=0, repo=repo
+    )
+    assert result.error is None
+    assert result.winner == "p1"
+    assert result.game["players"][1]["hp"] <= 0
+
+
+def test_game_be_003_2_s2_end_turn_emits_winner_on_bleeding_out_death(repo):
+    # opponent has 1 HP and empty deck → Bleeding Out reduces HP to 0
+    repo.save_game("g1", _game(hp_opp=1, opp_deck=[]))
+    result = end_turn_handler(game_id="g1", acting_player_id="p1", repo=repo)
+    assert result.error is None
+    assert result.winner == "p1"
+    assert result.game["players"][1]["hp"] == 0
+
+
+def test_game_be_003_2_s3_actions_rejected_on_finished_game(repo):
+    # store an already-finished game
+    finished = _game(hp_opp=0, mana=3, hand=[1])
+    finished["winner"] = "p1"
+    repo.save_game("g1", finished)
+    result = play_card_handler(
+        game_id="g1", acting_player_id="p1", card_index=0, repo=repo
+    )
+    assert result.error == "game over"

--- a/tests/test_is_game_over.py
+++ b/tests/test_is_game_over.py
@@ -1,0 +1,27 @@
+from domain.game import is_game_over
+from domain.models import GameState, Player
+
+
+def _state(hp_a=30, hp_b=30):
+    return GameState(
+        players=[
+            Player(id="p1", hp=hp_a, mana=0, mana_slots=0, hand=[], deck=[]),
+            Player(id="p2", hp=hp_b, mana=0, mana_slots=0, hand=[], deck=[]),
+        ],
+        active_player_index=0,
+    )
+
+
+def test_game_be_003_1_s1_returns_winner_when_opponent_at_zero_hp():
+    state = _state(hp_a=10, hp_b=0)
+    assert is_game_over(state) == "p1"
+
+
+def test_game_be_003_1_s2_returns_none_when_both_players_alive():
+    state = _state(hp_a=10, hp_b=10)
+    assert is_game_over(state) is None
+
+
+def test_game_be_003_1_s3_returns_winner_when_hp_negative():
+    state = _state(hp_a=10, hp_b=-3)
+    assert is_game_over(state) == "p1"


### PR DESCRIPTION
## Related Issue
Closes #16

## Changes
- Pure \`is_game_over(state) -> str | None\` in \`src/domain/game.py\`: returns the surviving player's id when any player's HP drops to 0 or below.
- \`play_card_handler\` and \`end_turn_handler\` now check \`is_game_over()\` after each mutation, persist \`winner\` onto the stored game, and return it on the result.
- Both handlers reject further actions with \`{"error": "game over"}\` once the game has a \`winner\`.
- Domain tests, handler-level tests, and story-level E2E (win by lethal card play; win by Bleeding Out on end turn).

This completes the 5/5 Pareto CORE stories at the BE layer.

## Testing
- [x] Full pytest suite: 40 passed
- [x] \`docker build\` + \`docker run --rm tcg-game\` pass
- [x] All pre-commit hooks pass