### PR TITLE
#19 [FEAT] GAME-STORY-004: Reject play when mana is insufficient

### DIFF
--- a/docs/user-stories/README.md
+++ b/docs/user-stories/README.md
@@ -36,7 +36,7 @@ Total stories written: 12/12 ✅
 | Story ID | Title | Written | Impl Status | File |
 |----------|-------|---------|-------------|------|
 | CONN-STORY-002 | Player disconnects cleanly | ✅ | TODO | [conn-story-002.md](conn-story-002.md) |
-| GAME-STORY-004 | Rule violation: insufficient mana rejected | ✅ | TODO | [game-story-004.md](game-story-004.md) |
+| GAME-STORY-004 | Rule violation: insufficient mana rejected | ✅ | DONE (BE; FE deferred) | [game-story-004.md](game-story-004.md) |
 | GAME-STORY-005 | Bleeding Out deals 1 damage on empty deck draw | ✅ | TODO | [game-story-005.md](game-story-005.md) |
 | GAME-STORY-006 | Overload discards card when hand is full | ✅ | TODO | [game-story-006.md](game-story-006.md) |
 | MATCH-STORY-002 | Player waits in queue with no opponent | ✅ | TODO | [match-story-002.md](match-story-002.md) |

--- a/tests/test_game_story_004_e2e.py
+++ b/tests/test_game_story_004_e2e.py
@@ -1,0 +1,64 @@
+import sqlite3
+
+import pytest
+
+from game.handlers import play_card_handler
+from matchmaking.handlers import join_queue
+from matchmaking.repository import MatchmakingRepository
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    return r
+
+
+def _arm(repo, hand, mana):
+    join_queue(player_id="A", repo=repo, now_epoch=1)
+    match = join_queue(player_id="B", repo=repo, now_epoch=2)
+    game = match.game
+    game["players"][0] = {
+        **game["players"][0],
+        "hand": hand,
+        "mana": mana,
+        "mana_slots": mana,
+    }
+    repo.save_game(game["game_id"], game)
+    return game
+
+
+def test_game_story_004_s1_insufficient_mana_rejected(repo):
+    # GIVEN the active player has 2 mana and a card costing 5
+    game = _arm(repo, hand=[5], mana=2)
+    active_id = game["players"][0]["id"]
+
+    # WHEN playCard runs
+    result = play_card_handler(
+        game_id=game["game_id"], acting_player_id=active_id, card_index=0, repo=repo
+    )
+
+    # THEN typed error is returned, game state is unchanged
+    assert result.error == "not enough mana"
+    assert result.game is None
+    stored = repo.get_game(game["game_id"])
+    assert stored["players"][0]["mana"] == 2
+    assert stored["players"][0]["hand"] == [5]
+
+
+def test_game_story_004_s2_invalid_card_index_rejected(repo):
+    # GIVEN the active player has a 2-card hand (indices 0 and 1)
+    game = _arm(repo, hand=[1, 2], mana=10)
+    active_id = game["players"][0]["id"]
+
+    # WHEN playCard runs with index 5
+    result = play_card_handler(
+        game_id=game["game_id"], acting_player_id=active_id, card_index=5, repo=repo
+    )
+
+    # THEN typed error is returned, state unchanged
+    assert result.error == "invalid card index"
+    assert result.game is None
+    stored = repo.get_game(game["game_id"])
+    assert stored["players"][0]["hand"] == [1, 2]


### PR DESCRIPTION
## Related Issue
Closes #19

## Changes
The domain-level rules for this story were already implemented as part of GAME-STORY-001 (\`play_card()\` raises \`RuleViolationError\` with messages \`"not enough mana"\` and \`"invalid card index"\`; \`play_card_handler\` catches and returns the typed error without persisting state).

This PR adds the missing story-level E2E tests exercising both scenarios through matchmaking → play_card_handler:

- GAME-STORY-004-S1: insufficient mana → \`{"error": "not enough mana"}\`, stored state unchanged.
- GAME-STORY-004-S2: invalid card index → \`{"error": "invalid card index"}\`, stored state unchanged.

Story inventory marked DONE (BE; FE deferred — no browser client yet).

## Testing
- [x] Full pytest suite: 42 passed
- [x] \`docker build\` + \`docker run --rm tcg-game\` pass
- [x] All pre-commit hooks pass