### PR TITLE
[FEAT] Add E2E tests for stories 005, 006, and MATCH-002

### DIFF
--- a/tests/test_game_story_005_e2e.py
+++ b/tests/test_game_story_005_e2e.py
@@ -1,0 +1,56 @@
+import sqlite3
+
+import pytest
+
+from game.handlers import end_turn_handler
+from matchmaking.handlers import join_queue
+from matchmaking.repository import MatchmakingRepository
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    return r
+
+
+def _arm_game(repo, opp_deck, opp_hp=30):
+    join_queue(player_id="A", repo=repo, now_epoch=1)
+    match = join_queue(player_id="B", repo=repo, now_epoch=2)
+    game = match.game
+    game["players"][1] = {**game["players"][1], "deck": opp_deck, "hp": opp_hp}
+    repo.save_game(game["game_id"], game)
+    return game
+
+
+def test_game_story_005_s1_bleeding_out_reduces_hp_by_1(repo):
+    # GIVEN opponent's deck is empty and HP is 30
+    game = _arm_game(repo, opp_deck=[])
+    active_id = game["players"][0]["id"]
+
+    # WHEN active player ends turn
+    result = end_turn_handler(
+        game_id=game["game_id"], acting_player_id=active_id, repo=repo
+    )
+
+    # THEN opponent HP reduced by 1, hand size unchanged, active player switches
+    assert result.error is None
+    assert result.game["players"][1]["hp"] == 29
+    opp_hand_before = len(game["players"][1]["hand"])
+    assert len(result.game["players"][1]["hand"]) == opp_hand_before
+    assert result.game["active_player_index"] == 1
+
+
+def test_game_story_005_s2_bleeding_out_can_trigger_win_condition(repo):
+    # GIVEN opponent has 1 HP and empty deck
+    game = _arm_game(repo, opp_deck=[], opp_hp=1)
+    active_id = game["players"][0]["id"]
+
+    # WHEN active player ends turn
+    result = end_turn_handler(
+        game_id=game["game_id"], acting_player_id=active_id, repo=repo
+    )
+
+    # THEN opponent HP drops to 0
+    assert result.game["players"][1]["hp"] == 0

--- a/tests/test_game_story_006_e2e.py
+++ b/tests/test_game_story_006_e2e.py
@@ -1,0 +1,56 @@
+import sqlite3
+
+import pytest
+
+from game.handlers import end_turn_handler
+from matchmaking.handlers import join_queue
+from matchmaking.repository import MatchmakingRepository
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    return r
+
+
+def _arm_game(repo, opp_deck, opp_hand):
+    join_queue(player_id="A", repo=repo, now_epoch=1)
+    match = join_queue(player_id="B", repo=repo, now_epoch=2)
+    game = match.game
+    game["players"][1] = {**game["players"][1], "deck": opp_deck, "hand": opp_hand}
+    repo.save_game(game["game_id"], game)
+    return game
+
+
+def test_game_story_006_s1_drawn_card_discarded_when_hand_is_full(repo):
+    # GIVEN opponent's hand has 5 cards and deck is non-empty
+    game = _arm_game(repo, opp_deck=[9, 8], opp_hand=[1, 2, 3, 4, 5])
+    active_id = game["players"][0]["id"]
+
+    # WHEN active player ends turn
+    result = end_turn_handler(
+        game_id=game["game_id"], acting_player_id=active_id, repo=repo
+    )
+
+    # THEN top card removed from deck, hand size remains 5
+    assert result.error is None
+    assert len(result.game["players"][1]["hand"]) == 5
+    assert result.game["players"][1]["deck"] == [8]
+
+
+def test_game_story_006_s2_normal_draw_when_hand_has_fewer_than_5_cards(repo):
+    # GIVEN opponent's hand has 4 cards and deck is non-empty
+    game = _arm_game(repo, opp_deck=[9, 8], opp_hand=[1, 2, 3, 4])
+    active_id = game["players"][0]["id"]
+
+    # WHEN active player ends turn
+    result = end_turn_handler(
+        game_id=game["game_id"], acting_player_id=active_id, repo=repo
+    )
+
+    # THEN card moved to hand, hand size becomes 5
+    assert result.error is None
+    assert len(result.game["players"][1]["hand"]) == 5
+    assert result.game["players"][1]["deck"] == [8]

--- a/tests/test_match_story_002_e2e.py
+++ b/tests/test_match_story_002_e2e.py
@@ -1,0 +1,41 @@
+import sqlite3
+
+import pytest
+
+from matchmaking.handlers import join_queue
+from matchmaking.repository import MatchmakingRepository
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    return r
+
+
+def test_match_story_002_s1_player_receives_waiting_when_queue_is_empty(repo):
+    # GIVEN the queue is empty
+    # WHEN a connected player joins
+    result = join_queue(player_id="player-1", repo=repo, now_epoch=1_700_000_000)
+
+    # THEN queue row written, waiting status returned, no game created
+    assert result.status == "waiting"
+    assert result.game is None
+    assert repo.peek_waiting().player_id == "player-1"
+
+
+def test_match_story_002_s2_queue_insert_is_idempotent_no_duplicate_row(repo):
+    # GIVEN a row for this player already exists in the queue
+    from matchmaking.repository import QueueEntry
+
+    repo.enqueue(QueueEntry(player_id="player-1", joined_at=1_700_000_000))
+
+    # WHEN the same player enqueues again (INSERT OR IGNORE)
+    repo.enqueue(QueueEntry(player_id="player-1", joined_at=1_700_000_001))
+
+    # THEN only one queue entry exists — no duplicate row written
+    count = repo._conn.execute(
+        "SELECT COUNT(*) FROM queue WHERE player_id = 'player-1'"
+    ).fetchone()[0]
+    assert count == 1


### PR DESCRIPTION
## Related Issues
Closes #20
Closes #21
Closes #22

## Changes
- Added dedicated E2E test file for GAME-STORY-005
- Added dedicated E2E test file for GAME-STORY-006
- Added dedicated E2E test file for MATCH-STORY-002

## Testing
- [x] Tested locally
- [x] Tests pass (52 passed)
- [x] Pre-commit hooks pass