### PR TITLE
[FEAT] GAME-STORY-007: Reconnect handler logic

### DIFF
--- a/src/game/handlers.py
+++ b/src/game/handlers.py
@@ -82,6 +82,13 @@ def play_card_handler(
     return PlayCardResult(game=new_dict, winner=winner)
 
 
+def rejoin(*, player_id: str, game_repo: MatchmakingRepository) -> dict:
+    game = game_repo.find_game_by_player(player_id)
+    if game is None:
+        return {"status": "no_active_game"}
+    return {"status": "rejoined", "game": game}
+
+
 def end_turn_handler(
     *,
     game_id: str,

--- a/src/matchmaking/repository.py
+++ b/src/matchmaking/repository.py
@@ -64,3 +64,11 @@ class MatchmakingRepository:
             "SELECT state_json FROM games WHERE game_id = ?", (game_id,)
         ).fetchone()
         return json.loads(row[0]) if row else None
+
+    def find_game_by_player(self, player_id: str) -> dict | None:
+        rows = self._conn.execute("SELECT state_json FROM games").fetchall()
+        for (state_json,) in rows:
+            state = json.loads(state_json)
+            if player_id in state.get("player_ids", []):
+                return state
+        return None

--- a/tests/test_game_be_rejoin_handler.py
+++ b/tests/test_game_be_rejoin_handler.py
@@ -1,0 +1,45 @@
+import sqlite3
+
+import pytest
+
+from game.handlers import rejoin
+from matchmaking.repository import MatchmakingRepository
+
+
+def _saved_game() -> dict:
+    return {
+        "game_id": "g1",
+        "player_ids": ["p1", "p2"],
+        "active_player_index": 0,
+        "players": [
+            {"id": "p1", "hp": 30, "mana": 3, "mana_slots": 3, "hand": [1], "deck": []},
+            {"id": "p2", "hp": 28, "mana": 0, "mana_slots": 2, "hand": [], "deck": [4]},
+        ],
+    }
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    r.save_game("g1", _saved_game())
+    return r
+
+
+def test_game_be_007_1_s1_active_game_found_returns_rejoined(repo):
+    # GIVEN the connectionId maps to a player with an active game
+    # WHEN the rejoin handler is invoked
+    result = rejoin(player_id="p1", game_repo=repo)
+    # THEN status is "rejoined" and game state is returned
+    assert result["status"] == "rejoined"
+    assert result["game"]["game_id"] == "g1"
+    assert result["game"]["players"][0]["id"] == "p1"
+
+
+def test_game_be_007_1_s2_no_active_game_returns_no_active_game(repo):
+    # GIVEN no game exists for this player
+    # WHEN the rejoin handler is invoked
+    result = rejoin(player_id="unknown_player", game_repo=repo)
+    # THEN status is "no_active_game"
+    assert result["status"] == "no_active_game"

--- a/tests/test_game_story_007_e2e.py
+++ b/tests/test_game_story_007_e2e.py
@@ -1,0 +1,46 @@
+import sqlite3
+
+import pytest
+
+from game.handlers import end_turn_handler, rejoin
+from matchmaking.handlers import join_queue
+from matchmaking.repository import MatchmakingRepository
+
+
+@pytest.fixture
+def repo():
+    conn = sqlite3.connect(":memory:")
+    r = MatchmakingRepository(conn)
+    r.init_schema()
+    return r
+
+
+def test_game_story_007_s1_reconnect_with_active_game(repo):
+    # GIVEN a game is in progress between two players
+    join_queue(player_id="alice", repo=repo, now_epoch=1)
+    match = join_queue(player_id="bob", repo=repo, now_epoch=2)
+    game = match.game
+    game_id = game["game_id"]
+
+    # Advance the game one turn so state has changed
+    active_id = game["players"][0]["id"]
+    end_turn_handler(game_id=game_id, acting_player_id=active_id, repo=repo)
+
+    # WHEN alice reconnects (simulated by calling rejoin with her player_id)
+    result = rejoin(player_id="alice", game_repo=repo)
+
+    # THEN she receives the current game state
+    assert result["status"] == "rejoined"
+    assert result["game"]["game_id"] == game_id
+    player_ids = [p["id"] for p in result["game"]["players"]]
+    assert "alice" in player_ids
+
+
+def test_game_story_007_s2_reconnect_with_no_active_game(repo):
+    # GIVEN no game exists for this player
+    # WHEN the player attempts to rejoin
+    result = rejoin(player_id="alice", game_repo=repo)
+
+    # THEN they are directed to the lobby
+    assert result["status"] == "no_active_game"
+    assert "game" not in result


### PR DESCRIPTION
Implements GAME-STORY-007: Reconnect restores in-progress game session

## Changes
- Added `find_game_by_player()` method to MatchmakingRepository
- Added `rejoin()` handler in game/handlers.py
- Handler returns active game state or no_active_game status

## Tests
- GAME-BE-007.1-S1: Active game found, state returned
- GAME-BE-007.1-S2: No active game, lobby status returned  
- GAME-STORY-007-S1: E2E reconnect with active game
- GAME-STORY-007-S2: E2E reconnect with no active game

All 54 tests pass.

Closes #23